### PR TITLE
examples for use in staging and production environments, updated cont…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,36 @@
 FROM node:15
+
 LABEL de.hs-fulda.netlab.name="prona/learn-sdn-hub" \
       de.hs-fulda.netlab.description="P4 and SDN learning environment" \
       de.hs-fulda.netlab.url="https://github.com/prona-p4-learning-platform/learn-sdn-hub" \
       de.hs-fulda.netlab.vcs-url="https://github.com/prona-p4-learning-platform/learn-sdn-hub" \
-      de.hs-fulda.netlab.docker.cmd="docker run -it --rm -p 3001:3001 prona/learn-sdn-hub 3001 127.0.0.1 22 p4 p4"
+      de.hs-fulda.netlab.docker.cmd="docker run -it --rm -p 3001:3001 prona/learn-sdn-hub -t localvm -a 127.0.0.1"
 
+# default port, can be overriden by using -p when running docker and as BACKEND_PORT using -p parameter of start-learn-sdn-hub.sh
 EXPOSE 3001/tcp
 
+# add a user 
 RUN useradd -m -s /bin/bash p4
 WORKDIR /home/p4/learn-sdn-hub
 
+# copy frontend and backend files to the image
 COPY frontend frontend
 COPY backend backend
 
+# ensure that development env file for environment was excluded
+RUN rm -rf frontend/.env.local
+
+# build backend and frontend
 RUN cd backend && npm install && npm run compile
 RUN cd frontend && npm install && npm run build
 
+# ensure that frontend will be served statically by the backend
+RUN rm -rf backend/static
+RUN mkdir -p backend/static
 RUN cp -a frontend/build/* backend/static/
 
-RUN echo '#!/bin/bash\n' \
-         'if [ ! $# -eq 5 ]\n' \
-         'then\n' \
-         '  echo "You need to specify a host used to run the P4 assignments.\nThis can be done, e.g., by running \"docker run -it --rm -p 3001:3001 prona/learn-sdn-hub <BACKEND_HTTP_PORT> <VBOX_IP_ADDRESS> <VBOX_SSH_PORT> <SSH_USERNAME> <SSH_PASSWORD>\"\n(see also VBOX_IP_ADDRESSES configuration etc. in learn-sdn-hub documentation)"\n' \
-         '  exit 1\n' \
-         'fi\n' \
-         'export BACKEND_HTTP_PORT=$1\n' \
-         'export VBOX_IP_ADDRESSES=$2\n' \
-         'export VBOX_SSH_PORTS=$3\n' \
-         'export SSH_USERNAME=$4\n' \
-         'export SSH_PASSWORD=$5\n' \
-         'cd backend && npm run start:localvm\n' >start-learn-sdn-hub.sh
+# copy example startup script and use it as the entrypoint when running the container
+COPY examples/start-learn-sdn-hub.sh start-learn-sdn-hub.sh
 RUN chmod +x start-learn-sdn-hub.sh
 
 ENTRYPOINT ["./start-learn-sdn-hub.sh"]

--- a/examples/Configuration.ts
+++ b/examples/Configuration.ts
@@ -1,0 +1,230 @@
+import { EnvironmentDescription } from "./P4Environment";
+
+const environments = new Map<string, EnvironmentDescription>();
+
+environments.set("Example1-Repeater", {
+  tasks: [
+    {
+      name: "bash",
+      cwd: "/home/p4/tmux/example1/",
+      executable: "./start-tmux-example1-bash",
+      params: [],
+      provideTty: true,
+    },
+    {
+      name: "bash2",
+      cwd: "/home/p4/tmux/example1/",
+      executable: "./start-tmux-example1-bash2",
+      params: [],
+      provideTty: true,
+    },
+  ],
+  editableFiles: [
+    {
+      absFilePath: "/home/p4/p4-boilerplate/Example1-Repeater/prona-repeater.p4",
+      alias: "prona-repeater.p4",
+    },
+    {
+      absFilePath: "/home/p4/p4-boilerplate/Example1-Repeater/Makefile",
+      alias: "Makefile",
+    },
+    {
+      absFilePath: "/home/p4/p4-boilerplate/Example1-Repeater/pod-topo/topology.json",
+      alias: "topology.json",
+    },
+    {
+      absFilePath: "/home/p4/p4-boilerplate/Example1-Repeater/pod-topo/s1-runtime.json",
+      alias: "s1-runtime.json",
+    },
+  ],
+  stopCommands: [
+    {
+      name: "bash",
+      cwd: "/home/p4/",
+      executable: "exit",
+      params: [],
+      provideTty: false,
+    },
+    {
+      name: "bash2",
+      cwd: "/home/p4/",
+      executable: "exit",
+      params: [],
+      provideTty: false,
+    },
+  ],
+  description: "Example1-Repeater",
+  assignmentLabSheet: "../assignments/prona-repeater.md",
+});
+
+environments.set("Example2-MinimalisticSwitch", {
+  tasks: [
+  {
+    name: "bash",
+    cwd: "/home/p4/tmux/example2/",
+    executable: "./start-tmux-example2-bash",
+    params: [],
+    provideTty: true,
+  },
+  {
+    name: "bash2",
+    cwd: "/home/p4/tmux/example2/",
+    executable: "./start-tmux-example2-bash2",
+    params: [],
+    provideTty: true,
+  },
+],
+editableFiles: [
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example2-MinimalisticSwitch/prona-switch-static-table.p4",
+    alias: "prona-switch-static-table.p4",
+  },
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example2-MinimalisticSwitch/Makefile",
+    alias: "Makefile",
+  },
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example2-MinimalisticSwitch/pod-topo/topology.json",
+    alias: "topology.json",
+  },
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example2-MinimalisticSwitch/pod-topo/s1-runtime.json",
+    alias: "s1-runtime.json",
+  },
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example2-MinimalisticSwitch/alternative/prona-switch-static-naive.p4",
+    alias: "prona-switch-static-naive.p4",
+  },
+],
+stopCommands: [
+  {
+    name: "bash",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+  {
+    name: "bash2",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+],
+description: "Example2-MinimalisticSwitch",
+assignmentLabSheet: "../assignments/prona-minimalisticswitch.md",
+});
+
+environments.set("Example3-LearningSwitch", {
+tasks: [
+  {
+    name: "bash",
+    cwd: "/home/p4/tmux/example3/",
+    executable: "./start-tmux-example3-bash",
+    params: [],
+    provideTty: true,
+  },
+  {
+    name: "bash2",
+    cwd: "/home/p4/tmux/example3/",
+    executable: "./start-tmux-example3-bash2",
+    params: [],
+    provideTty: true,
+  },
+  {
+    name: "bash3",
+    cwd: "/home/p4/tmux/example3/",
+    executable: "./start-tmux-example3-bash3",
+    params: [],
+    provideTty: true,
+  },
+],
+editableFiles: [
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example3-LearningSwitch/p4src/prona-switch-learning.p4",
+    alias: "prona-switch-learning.p4",
+  },
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example3-LearningSwitch/learning_switch_controller_app.py",
+    alias: "learning_switch_controller_app.py",
+  },
+  {
+    absFilePath: "/home/p4/p4-boilerplate/Example3-LearningSwitch/p4app.json",
+    alias: "p4app.json",
+  },
+],
+stopCommands: [
+  {
+    name: "bash",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+  {
+    name: "bash2",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+  {
+    name: "bash3",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+],
+description: "Example3-LearningSwitch",
+assignmentLabSheet: "../assignments/prona-learningswitch.md",
+});
+environments.set("Example-p4env", {
+tasks: [
+  {
+    name: "bash",
+    cwd: "/home/p4/tmux/example4/",
+    executable: "./start-tmux-example4-bash",
+    params: [],
+    provideTty: true,
+  },
+  {
+    name: "bash2",
+    cwd: "/home/p4/tmux/example4/",
+    executable: "./start-tmux-example4-bash2",
+    params: [],
+    provideTty: true,
+  },
+],
+editableFiles: [
+  {
+    absFilePath: "/home/p4/p4environment/p4programs/l2_forwarding_static/l2_forwarding_static.p4",
+    alias: "l2_forwarding_static.p4",
+  },
+  {
+    absFilePath: "/home/p4/p4environment/p4topos/diamond_shape/topology.json",
+    alias: "topology.json",
+  },
+],
+stopCommands: [
+  {
+    name: "bash",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+  {
+    name: "bash2",
+    cwd: "/home/p4/",
+    executable: "exit",
+    params: [],
+    provideTty: false,
+  },
+],
+description: "Example-p4env",
+assignmentLabSheet: "../assignments/p4env.md",
+});
+
+export default environments;

--- a/examples/assignments/p4env.md
+++ b/examples/assignments/p4env.md
@@ -1,0 +1,10 @@
+# Example p4environment
+
+This example uses the p4environment (p4env) developed at NetLab of Fulda University
+of Applied Sciences. p4env contains a comprehensive framework leveraring the
+P4 toolchain to build and run P4 programs, topologies (based on mininet),
+switches, controllers and monitors. 
+
+This example provides an empty setup as a starting point. Detailed
+documentation and example usage is provided at:
+<https://gitlab.cs.hs-fulda.de/flow-routing/cnsm2020/p4environment>

--- a/examples/assignments/prona-learningswitch.md
+++ b/examples/assignments/prona-learningswitch.md
@@ -1,0 +1,94 @@
+# Example 3: Learning Switch (L2 Forwarding incl. Flood & Filter)
+
+## Background
+
+This lab is based on the
+[p4-learning](https://github.com/nsg-ethz/p4-learning) environment.
+You can find further details regarding the implementation of a learning
+switch in the corresponding
+[exercise](https://github.com/nsg-ethz/p4-learning/tree/master/exercises/04-L2_Learning) by NSG-ETHZ.
+
+## Implementing a Learning Switch
+
+* Switch forwards Layer 2 frames, based on destination MAC address, learned from received frames source MAC address
+* Flood & Filter functionality of a typical Layer 2 switch
+  * Source MAC addresses from received packets should be learned (i.e., inserted in the MAC address table as future destinations) referencing the ingress port
+  * If destination MAC address is not in the table or multicast/broadcast addressis used, flood the packet to all other egress ports (excluding the ingress port)
+  * If destination MAC address is in the table, only use the egress port referenced in the table entry to forward the packet
+
+```mermaid
+    graph LR;
+        H1---P4-Switch;
+        P4-Switch---H2;
+        P4-Switch---H3;
+```
+
+```
+H1 @ Port 1 of P4-Switch, MAC: 00:00:00:00:00:01
+H2 @ Port 2 of P4-Switch, MAC: 00:00:00:00:00:02
+H3 @ Port 3 of P4-Switch, MAC: 00:00:00:00:00:03
+```
+
+## P4Runtime / Control Plane
+* We already implemented the Flooding (Broadcast) and Filtering (MAC address table) in the static switch
+* How can we implement the learning part?
+  * Learning was manually carried out using the CLI to add a table entry
+  * CLI, API, gRPC etc. could be used to automatethis manual process (e.g., using a Python program)
+  * This leads to the implementation of a smallControl Plane App to change switch config/logicduring runtime
+  * We'll use the CPU port to inform our App, thata new MAC address was seen and insertinga new entry for this address in the table
+
+## Extending the minimalistic switch to become a learning switch
+
+### Add an additional srcMacAddr table
+
+* Add a table to learn source MAC address, idea: if incoming source MAC address is already in the table -> do nothing (NoAction)
+* if MAC address is not in the table, learn it by cloning the packet from ingress to egress (I2E) and sending it to the CPU port (using a port mirror in the switch)
+
+### Add a new CPU packet protocol to be used to send learned MAC addresses to controller
+
+* Use a custom CPU header to packets to controller via CPU port (containing MAC address to learn on ingress port)
+* Be sure to add the cpu header to the deparser to include it in the outgoing packet
+
+## Implement a controller app (learning_switch_controller_app_p4-learning.py)
+
+* Implementation of a Python App on Control Plane using P4Runtime
+* Uses Switch API to execute RuntimeCmds (which we did manually before), hence configuring table entries, multicast groups and mirror sessions during runtime
+* Uses scapy to sniff on CPU port and use received packets (using the defined CPU header) to learn new MAC addresses and inserting them in the tables
+
+### Initialization
+
+* Upon initialization of the LearningSwitchControllerApp class, establish connection to Switch in running topology (uses p4-utils of  nsg-ethz)
+* Add mcast groups to switch
+* Add mirror session (to mirror packets to the CPU port) to the switch
+
+### Adding mcast group and mirror using API instead of CLI
+
+* Add mcast groups to switch using API, this is what we did manually before by using ```mc_mgrp_create```, ```mc_node_create``` and ```mc_node_associate```
+* Add mirror session (could also be done manually using the CLI)
+
+### Receive incoming CPU packets from mirror and add learned MAC addresses to srcMacAddr and dstMacAddr table
+
+* Continuously sniff for packets on cpu port interface and treat received packets as information to learn about new mac addresses on ingress ports
+* Add learned MAC addresses and their ports using switch API for table_add
+
+## Task 1: Start controller
+
+* Start the controller and see how it learns MAC addresses
+* Start a ping from H1 to H2
+* Are any packets sent from H1 to H2 also received by H3? Which ones? Why?
+
+## Task 2: Remove learned MAC addresses from dstMacAddr table
+
+* Remove all entries from dstMacAddr table
+* Start a ping from H1 to H2 again
+* Are any packets sent from H1 to H2 also received by H3? Which ones? Why?
+
+## Discussion of ProNA P4 Learning Switch and possible next steps 
+
+* Switch forwards Layer 2 frames, based on destination MAC address
+* Implements flood & filter function of typical Layer 2 switch
+* Broadcasts and packets going to unknown unicast MAC addresses are flooded to all ports except the port that the packet arrived on, try to comment out table_add to see every packet being flooded... same holds true when table is full... same for real-world switches...
+* Packets destined to known unicast MAC addresses are forwarded only to the learned ports
+* Implementation is still very basic, compared to real-world switches
+* No "delearning"/aging of table entries, no VLANs, ... etc.
+* Yet, now we saw all essential ingredients to implement more sophisticatednetwork elements and their functions

--- a/examples/assignments/prona-minimalisticswitch.md
+++ b/examples/assignments/prona-minimalisticswitch.md
@@ -1,0 +1,65 @@
+# Example 2: Minimalistic Switch (L2 Forwarding)
+
+## Implementing a Switch
+
+* Switch forwards Layer 2 frames, based on destination MAC address
+* Correspondingly, topology now mentions MAC address of each host
+* All frames reaching the switch with a destination MAC address of 00:00:00:00:00:02 should go out on Port 2, same for MAC address of H1 on Port 1
+  * Layer 2 Ethernet header needs to be parsed
+  * As for real-world Layer 2 network elements, switch needs a table to matchincoming destination MAC address and select approriate egress port
+
+```mermaid
+    graph LR;
+        H1---P4-Switch;
+        P4-Switch---H2;
+```
+
+```
+H1 @ Port 1 of P4-Switch, MAC: 00:00:00:00:00:01
+H2 @ Port 2 of P4-Switch, MAC: 00:00:00:00:00:02
+```
+
+## Parser
+
+* extract takes 48 + 48 + 16 bits (14 bytes) from the beginning of the packet
+* Be sure to deparse all previously parsed and extracted or modified header data in egress
+
+## Naive Layer 2 Forwarding
+
+* Can we use the extracted header fields afterwards directly to do the following?
+
+```
+if (hdr.ethernet.dstAddr == 0x000000000001) { std_meta.egress_spec = 1; }
+if (hdr.ethernet.dstAddr == 0x000000000002) { std_meta.egress_spec = 2; }
+```
+
+* That's possible and not as dumb as the repeater... but what about additional hosts? Where to send broadcast destination? Better use a MAC address table for match-action...
+
+## Table-based Layer 2 Forwarding
+
+* Define table with destination MAC address as key, for entry/line in table two actions are possible: forward or broadcast (default, e.g., for unknown MAC address or multicast/broadcast)
+* Action forward is called like a function, getting egress_port as parameter, sets outgoing port (egress_spec) to port defined for MAC address in the table
+* Action broadcast sets multicast group in standard metadata of switch (V1Model broadcast support)
+* What will happen, when we start the switch like this? Which MAC addresses will be matched?
+
+* We need to make sure, that broadcasts only go out to "all *other* ports" and not the one they where received on
+* Hence drop broadcasts if they are about to go out on the port they came in from
+```(std_meta.egress_port == std_meta.ingress_port)```
+
+## Task 1: Add entries for MAC addresses to MyIngress.dstMacAddr using simple_switch_CLI
+
+* Need to add entries to table during runtime, P4 code only specifies data plane logic, runtime handled by P4Runtime and Control Plane
+* Can use Python API, gRPC or directly the CLI of the switch
+* Add entries for MAC address of each host to MyIngress.dstMacAddr, specifying action (forward) and parameter (egress port)
+
+## Task 2: Add a multicast group using simple_switch_CLI
+
+* Need to create multicast group 1 (std_meta.mcast_grp = 1), by default switch does not know which ports should belong to the same broadcast domain (e.g., VLAN)
+* Create a node 0 and add all ports (1, 2) to it
+* Associate the node 0 to multicast group 1
+...after adding this multicast group, we could even delete all entries in table dstMacAddr, as unknown MAC addresses (not having an entry in the table) will default to broadcast
+
+## Result and next steps
+
+* "h1 ping h2" will work... and we created a static Layer 2 switch. 
+* How can we implement dynamic MAC address learning (also known as "flooding and filtering")?

--- a/examples/assignments/prona-repeater.md
+++ b/examples/assignments/prona-repeater.md
@@ -1,0 +1,33 @@
+# Example 1: Repeater (aka Hub)
+
+## Implementing a Repeater
+
+* Repeater forwards data received on one port to all other ports
+* Simple topology: host H1 and H2, connected to each port of the repeater
+* All data received from H1 on port 1 should be forwarded to port 2 and vice versa
+  * Repeater does not need to support and hence parse headers
+  * Literally protocol-independent, just forwarding received/incoming data
+
+```mermaid
+    graph LR;
+        H1---P4-Repeater;
+        P4-Repeater---H2;
+```
+
+## Discussion of ProNA P4 Repeater
+
+```
+if (std_meta.ingress_port == 1) { std_meta.egress_spec = 2; }
+if (std_meta.ingress_port == 2) { std_meta.egress_spec = 1; }
+```
+
+* standard_metadata contains context information from switch pipeline
+* ingress_port -> Port on which the packet came in 
+* egress_spec -> spec(ification) of the port the packet should go out on
+* "Software-defined" network logic: condition for repeater ports, define egress_port
+* Only two lines of code needed in boilerplate to make "h1 ping h2" work
+* However, the approach has several limitations: 
+  * Repeater is rather dumb. How to build smarter network elements, being aware of traffic metadata?
+  * How to include dynamic routing and forwarding decisions using a control plane during runtime?
+  * How to handle traffic between more than two ports?
+  * We'll address these challenges gradually in the next examples...

--- a/examples/docker-container-scripts/login-to-learn-sdn-hub-docker
+++ b/examples/docker-container-scripts/login-to-learn-sdn-hub-docker
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker exec -it learn-sdn-hub bash

--- a/examples/docker-container-scripts/restart-learn-sdn-hub-docker
+++ b/examples/docker-container-scripts/restart-learn-sdn-hub-docker
@@ -1,0 +1,3 @@
+#!/bin/bash
+./stop-learn-sdn-hub-docker
+./start-learn-sdn-hub-docker

--- a/examples/docker-container-scripts/show-log-learn-sdn-hub-docker
+++ b/examples/docker-container-scripts/show-log-learn-sdn-hub-docker
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker logs --tail 100 -f learn-sdn-hub

--- a/examples/docker-container-scripts/start-learn-sdn-hub-docker
+++ b/examples/docker-container-scripts/start-learn-sdn-hub-docker
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# example using LocalMultiuserVM provider:
+
+export BACKEND_HTTP_PORT="16000"
+export BACKEND_TYPE="localmultiuservm"
+export VBOX_IP_ADDRESSES="172.20.9.1,172.20.11.1,172.20.12.1,172.20.13.1,172.20.14.1,172.20.15.1,172.20.16.1,172.20.17.1,172.20.18.1"
+export VBOX_SSH_PORTS="22,22,22,22,22,22,22,22,22"
+export SSH_USERNAME="p4"
+export SSH_PASSWORD="p4"
+export BACKEND_USERS="group00:p4,group01:password,group02:password,group03:password,group04:password,group05:password,group06:password,group07:password,group08:password"
+export BACKEND_USER_MAPPING="group00:0,group01:1,group02:2,group03:3,group04:4,group05:5,group06:6,group07:7,group08:8"
+
+docker run --restart=always -itd --name learn-sdn-hub \
+  --mount type=bind,source="$(pwd)"/assignments,target=/home/p4/learn-sdn-hub/backend/src/assignments \
+  --mount type=bind,source="$(pwd)"/Configuration.ts,target=/home/p4/learn-sdn-hub/backend/src/Configuration.ts \
+  -p 16000:16000 prona/learn-sdn-hub \
+  -p $BACKEND_HTTP_PORT \
+  -t $BACKEND_TYPE \
+  -a $VBOX_IP_ADDRESSES \
+  -s $VBOX_SSH_PORTS \
+  -u $SSH_USERNAME \
+  -w $SSH_PASSWORD \
+  -b $BACKEND_USERS \
+  -m $BACKEND_USER_MAPPING
+
+# example using LocalVM provider:
+#
+#export BACKEND_HTTP_PORT="16000"
+#export BACKEND_TYPE="localvm"
+#export VBOX_IP_ADDRESSES="172.20.9.1,172.20.11.1,172.20.12.1"
+#export VBOX_SSH_PORTS="22,22,22"
+#export SSH_USERNAME="p4"
+#export SSH_PASSWORD="p4"
+#
+#docker run --restart=always -itd --name learn-sdn-hub \
+#  --mount type=bind,source="$(pwd)"/assignments,target=/home/p4/learn-sdn-hub/backend/src/assignments \
+#  --mount type=bind,source="$(pwd)"/Configuration.ts,target=/home/p4/learn-sdn-hub/backend/src/Configuration.ts \
+#  -p 16000:16000 prona/learn-sdn-hub \
+#  -p $BACKEND_HTTP_PORT \
+#  -t $BACKEND_TYPE \
+#  -a $VBOX_IP_ADDRESSES \
+#  -s $VBOX_SSH_PORTS \
+#  -u $SSH_USERNAME \
+#  -w $SSH_PASSWORD \
+
+# example using OpenStack provider:
+#
+#export BACKEND_HTTP_PORT="16000"
+#export BACKEND_TYPE="openstack"
+#export SSH_USERNAME="p4"
+#export SSH_PASSWORD="p4"
+#
+#docker run --restart=always -itd --name learn-sdn-hub \
+#  --mount type=bind,source="$(pwd)"/assignments,target=/home/p4/learn-sdn-hub/backend/src/assignments \
+#  --mount type=bind,source="$(pwd)"/Configuration.ts,target=/home/p4/learn-sdn-hub/backend/src/Configuration.ts \
+#  -p 16000:16000 prona/learn-sdn-hub \
+#  -p $BACKEND_HTTP_PORT \
+#  -t $BACKEND_TYPE \
+#  -u $SSH_USERNAME \
+#  -w $SSH_PASSWORD \
+
+#run container without start script for learn-sdn-hub:
+#
+#docker run --restart=always -itd --name learn-sdn-hub --entrypoint bash \
+#  --mount type=bind,source="$(pwd)"/assignments,target=/home/p4/learn-sdn-hub/backend/src/assignments \
+#  --mount type=bind,source="$(pwd)"/Configuration.ts,target=/home/p4/learn-sdn-hub/backend/src/Configuration.ts \
+#  -p 16000:16000 prona/learn-sdn-hub

--- a/examples/docker-container-scripts/stop-learn-sdn-hub-docker
+++ b/examples/docker-container-scripts/stop-learn-sdn-hub-docker
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker kill learn-sdn-hub
+docker rm learn-sdn-hub

--- a/examples/docker-container-scripts/update-learn-sdn-hub-docker
+++ b/examples/docker-container-scripts/update-learn-sdn-hub-docker
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker pull prona/learn-sdn-hub

--- a/examples/start-learn-sdn-hub.sh
+++ b/examples/start-learn-sdn-hub.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+function usage ()
+{
+cat <<EOF
+Usage:  start-learn-sdn-hub.sh [OPTIONS]
+
+Example start script for ProNA learn-sdn-hub backend.
+
+Options:
+  -h         print this help message
+
+  Mandatory:
+  -t type    host instance type to run assignments on, can be
+             <localvm, localmultiuservm, openstack>
+
+  Optional:
+  -p port    HTTP TCP port the backend listens on for incoming requests
+             (BACKEND_HTTP_PORT, default: 3001)
+
+  -a list    comma-separated list of addresses to be used as hosts users run
+             assignments on (VBOX_IP_ADDRESSES, required for localvm and
+             localmultiuservm)
+  -s list    comma-separated list of SSH ports to be used for the hosts users
+             run assignments on if using localvm or localmultiuservm 
+             (VBOX_SSH_PORTS, default: 22 for all hosts, required for localvm
+             and localmultiuservm)
+
+  -u string  username to use for the SSH connection to the hosts (SSH_USERNAME,
+             default: p4)
+  -w string  password to use for the SSH connection to the hosts (SSH_PASSWORD,
+             default: p4)
+
+  -b list    comma-separated list of username:password, to be used to login to
+             the backend if localmultiuservm is used (BACKEND_USERS, required
+             for localmultiuservm)
+  -m list    comma-separated list of username:instanceNumber, to map users to
+             host instance, instanceNumber is pointing to list specified in 
+             VBOX_IP_ADDRESSES beginning with 0 (BACKEND_USER_MAPPING, if not
+             specified when using localmultiuservm, all users will be mapped to
+             the first host instance)
+EOF
+}
+ 
+unset BACKEND_HTTP_PORT
+unset BACKEND_TYPE
+
+unset VBOX_IP_ADDRESSES
+unset VBOX_SSH_PORTS
+
+unset SSH_USERNAME
+unset SSH_PASSWORD
+
+unset BACKEND_USERS
+unset BACKEND_USER_MAPPING
+
+while getopts ":hp:t:a:s:u:w:b:m:" opt; do
+  case $opt in
+        h)
+            usage; exit 0 ;;
+        p)
+            export BACKEND_HTTP_PORT=$OPTARG ;;
+        t)
+            export BACKEND_TYPE=":$OPTARG" ;;
+        a)
+            export VBOX_IP_ADDRESSES="$OPTARG" ;;
+        s)
+            export VBOX_SSH_PORTS="$OPTARG" ;;
+        u)
+            export SSH_USERNAME="$OPTARG" ;;
+        w)
+            export SSH_PASSWORD="$OPTARG" ;;
+        b)
+            export BACKEND_USERS="$OPTARG" ;;
+        m)
+            export BACKEND_USER_MAPPING="$OPTARG" ;;
+        :)
+            echo "bad option arg $OPTARG."
+            usage
+            exit 1
+            ;;
+        \?)
+            echo "bad option $1"
+            usage
+            exit 1
+            ;;
+  esac
+done
+ 
+shift $((OPTIND-1))
+
+if [ "$BACKEND_HTTP_PORT" == "" ] ; then
+  echo "BACKEND_HTTP_PORT not specified, backend will use default port: 3001"
+else
+  echo "BACKEND_HTTP_PORT: $BACKEND_HTTP_PORT"
+fi
+
+if [ -z ${BACKEND_TYPE} ] ; then
+  echo "ERROR: BACKEND_TYPE not specified, must be localvm, localmultivm or openstack"
+  usage
+  exit 1
+elif [ "$BACKEND_TYPE" == ":openstack" ] ; then
+  # currently openstack provider is the default, and is started using 
+  # "npm run start", hence also set BACKEND_TYPE to "" in case of openstack
+  export BACKEND_TYPE=""
+  echo "BACKEND_TYPE not specified, backend will be started using default host instance provider (OpenStack)"
+else
+  if [ "$BACKEND_TYPE" == ":localvm" ] || [ "$BACKEND_TYPE" == ":localmultiuservm" ] ; then
+    echo "BACKEND_TYPE: $BACKEND_TYPE"
+  else
+    echo "ERROR: illegal BACKEND_TYPE, must be localvm, localmultivm or openstack"
+    usage
+    exit 1
+  fi
+fi
+
+if [ -z ${VBOX_IP_ADDRESSES} ] ; then
+  if [ "$BACKEND_TYPE" == ":localvm" ] || [ "$BACKEND_TYPE" == ":localmultiuservm" ] ; then
+    echo "ERROR: option -a must be specified when using localvm or localmultiuservm as host instance type (VBOX_IP_ADDRESSES)"
+    usage
+    exit 1
+  fi
+else
+  echo "VBOX_IP_ADDRESSES: $VBOX_IP_ADDRESSES"
+fi
+
+if [ "$VBOX_SSH_PORTS" == "" ] ; then
+  echo "VBOX_SSH_PORTS not specified, backend will use default port 22 for all host instances"
+else
+  echo "VBOX_SSH_PORTS: $VBOX_SSH_PORTS"
+fi
+
+if [ "$SSH_USERNAME" == "" ] ; then
+  echo "SSH_USERNAME not specified, backend will connect to host instances using default username: p4"
+else
+  echo "SSH_USERNAME: $SSH_USERNAME"
+fi
+
+if [ "$SSH_PASSWORD" == "" ] ; then
+  echo "SSH_PASSWORD not specified, backend will connect to host instances using default password: p4"
+else
+  echo "SSH_PASSWORD: $SSH_PASSWORD"
+fi
+
+if [ -z ${BACKEND_USERS} ] ; then
+  if [ "$BACKEND_TYPE" == ":localmultiuservm" ] ; then
+    echo "ERROR: option -b must be specified when using localmultiuservm as host instance type (BACKEND_USERS)"
+    usage
+    exit 1
+  fi
+else
+  echo "BACKEND_USERS: $BACKEND_USERS"
+fi
+
+if [ -z ${BACKEND_USER_MAPPING} ] ; then
+  if [ "$BACKEND_TYPE" == ":localmultiuservm" ] ; then
+    echo "BACKEND_USER_MAPPING not specified and type localmultiuservm is used, all users will be mapped to the first host instance"
+  fi
+else
+  if [ "$BACKEND_TYPE" == ":localmultiuservm" ] ; then
+    echo "BACKEND_USER_MAPPING: $BACKEND_USER_MAPPING"
+  else
+    echo "BACKEND_USER_MAPPING will be ignored as backend type is not localmultiuservm"
+  fi
+fi
+
+echo
+echo "Starting learn-sdn-hub..."
+
+cd backend && npm run start$BACKEND_TYPE

--- a/examples/tmux/example1/start-tmux-example1-bash
+++ b/examples/tmux/example1/start-tmux-example1-bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex1-bash"
+WORKDIR="/home/p4/p4-boilerplate/Example1-Repeater"
+COMMAND="make clean && make"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example1/start-tmux-example1-bash2
+++ b/examples/tmux/example1/start-tmux-example1-bash2
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex1-bash2"
+WORKDIR="/home/p4/p4-boilerplate/Example1-Repeater"
+COMMAND="ls -al"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example2/start-tmux-example2-bash
+++ b/examples/tmux/example2/start-tmux-example2-bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex2-bash"
+WORKDIR="/home/p4/p4-boilerplate/Example2-MinimalisticSwitch"
+COMMAND="make clean && make"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example2/start-tmux-example2-bash2
+++ b/examples/tmux/example2/start-tmux-example2-bash2
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex2-bash2"
+WORKDIR="/home/p4/p4-boilerplate/Example2-MinimalisticSwitch"
+COMMAND="ls -al"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example3/start-tmux-example3-bash
+++ b/examples/tmux/example3/start-tmux-example3-bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex3-bash"
+WORKDIR="/home/p4/p4-boilerplate/Example3-LearningSwitch"
+COMMAND="sudo p4run"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example3/start-tmux-example3-bash2
+++ b/examples/tmux/example3/start-tmux-example3-bash2
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex3-bash2"
+WORKDIR="/home/p4/p4-boilerplate/Example3-LearningSwitch"
+COMMAND="ls -al"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example3/start-tmux-example3-bash3
+++ b/examples/tmux/example3/start-tmux-example3-bash3
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex3-bash3"
+WORKDIR="/home/p4/p4-boilerplate/Example3-LearningSwitch"
+COMMAND="ls -al"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example4/start-tmux-example4-bash
+++ b/examples/tmux/example4/start-tmux-example4-bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex4-bash"
+WORKDIR="/home/p4/p4environment/"
+COMMAND="sudo python p4runner.py"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION

--- a/examples/tmux/example4/start-tmux-example4-bash2
+++ b/examples/tmux/example4/start-tmux-example4-bash2
@@ -1,0 +1,12 @@
+#!/bin/bash
+SESSION="Ex4-bash2"
+WORKDIR="/home/p4/p4environment/"
+COMMAND="ls -al"
+
+tmux start-server
+tmux has-session -t $SESSION 2>/dev/null
+if [ $? != 0 ]; then
+  tmux new-session -d -n $SESSION -s $SESSION
+  tmux send-keys -t $SESSION "cd $WORKDIR" Enter "$COMMAND" Enter
+fi
+tmux attach-session -t $SESSION


### PR DESCRIPTION
…ainer image creation and documentation. Possibly closes #18 as commented there. Backend documentation and examples are rather feature-complete for now - at least as an initial draft. Also locking containers in a specific env would be possible using the described config and exmaples. P4 deployment should however not be included together with the learn-sdn-hub container image. I changed my mind in this regard. learn-sdn-hub is not necessarily limeted to be used with P4. Rather than using the container to also run assignments in it, separate host instance setup is more flexible and more appropriate, as already suggested by @PBug90  before, if I remember correctly. Therefore, I'll be focussing on p4-container repo to be served as an example to setup host instances being able to run P4 assignements using learn-sdn-hub, but not include P4 toolchain deployment here.