### PR TITLE
fixed dynamic generation of backendURL. Backend connection only worke…

### DIFF
--- a/frontend/src/api/Config.ts
+++ b/frontend/src/api/Config.ts
@@ -1,9 +1,9 @@
 const hostname = window?.location?.hostname ?? "localhost";
-const port = window?.location?.port ?? "3001";
+const port = process.env.REACT_APP_BACKEND_HTTP_PORT ?? "3001";
 const protocol = window?.location?.protocol ?? "http";
-const backendURL = process.env.REACT_APP_API_HOST ?? `${protocol}://${hostname}:${port}`;
-const wsProtocol = protocol === "http" ? "ws": "wss"
-const wsBackendHost = process.env.REACT_APP_WS_HOST ?? `${wsProtocol}://${hostname}:${port}`;
+const backendURL = process.env.REACT_APP_API_HOST ?? `${protocol}//${hostname}:${port}`;
+const wsProtocol = protocol === "http:" ? "ws:": "wss:"
+const wsBackendHost = process.env.REACT_APP_WS_HOST ?? `${wsProtocol}//${hostname}:${port}`;
 
 export default {
     backendURL,


### PR DESCRIPTION
…d when using REACT_APP_API_URL and REACT_APP_WS_URL etc. in .env.local. Config.ts should generate backend connection, and this will not be 3000 but rather 3001 by default. Also added option to adapt changed backend port. Also window.location.protocol already contains trailing :, so the code led to http://localhost:3001/http:://localhost:3000/some/api/dir being created.