### PR TITLE
reverted removal of partially unused identifier arg that was suggeste…

### DIFF
--- a/backend/src/P4Environment.ts
+++ b/backend/src/P4Environment.ts
@@ -134,12 +134,16 @@ export default class P4Environment {
             this.userId,
             filtered[0].identifier
           );
-          return this.environmentProvider.createServer();
+          return this.environmentProvider.createServer(
+            `${this.userId}-${this.configuration.description}`
+          );
         }
         throw err;
       }
     } else {
-      return this.environmentProvider.createServer();
+      return this.environmentProvider.createServer(
+        `${this.userId}-${this.configuration.description}`
+      );
     }
   }
 

--- a/backend/src/providers/LocalVMProvider.ts
+++ b/backend/src/providers/LocalVMProvider.ts
@@ -41,7 +41,7 @@ export default class LocalVMProvider implements InstanceProvider {
     return this.availableInstances.get(identifier);
   }
 
-  async createServer(): Promise<VMEndpoint> {
+  async createServer(identifier: string): Promise<VMEndpoint> {
     if (this.availableInstancesList.length > 0) {
       return this.availableInstances.get(this.availableInstancesList.pop());
     }

--- a/backend/src/providers/Provider.ts
+++ b/backend/src/providers/Provider.ts
@@ -6,5 +6,5 @@ export interface VMEndpoint {
 }
 export interface InstanceProvider {
   getServer(identifier: string): Promise<VMEndpoint>;
-  createServer(): Promise<VMEndpoint>;
+  createServer(identifier: string): Promise<VMEndpoint>;
 }


### PR DESCRIPTION
…d by linter warning

intentifier cannot be completely removed as suggested by the linter warning, otherwise some providers that depend on it will not start