### PR TITLE
disabled react18 strictmode

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,9 +8,17 @@ const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  //TODO: change websockets for terminals in the frontend (Terminal.tsx) to support new React 18 behevior componentWillUnmount
+  //
+  //  see: 
+  //    - https://reactjs.org/docs/strict-mode.html (With Strict Mode starting in React 18, whenever a component mounts in development, React will simulate immediately unmounting and remounting the component:)
+  //    - https://reactjs.org/blog/2022/03/29/react-v18.html
+  //
+  //  After the update, StrictMode can be enabled again
+
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
temporarily disabled react 18 StrictMode to fix close of websocket connection before terminal is active when using development server.

Thanks for @PBug90 for pointing out this solution!