### PR TITLE
Removed umlaut from sdn lab example

### DIFF
--- a/backend/src/Configuration.ts
+++ b/backend/src/Configuration.ts
@@ -267,7 +267,7 @@ environments.set("Example0-SDN-Intro", {
   assignmentLabSheet: "../assignments/prona-sdn-intro.md",
 });
 
-environments.set("Beispiel0-SDN-Einführung", {
+environments.set("Beispiel0-SDN-Einfuehrung", {
   tasks: [
     [
       {
@@ -314,7 +314,7 @@ environments.set("Beispiel0-SDN-Einführung", {
       provideTty: false,
     },
   ],
-  description: "Beispiel0-SDN-Einführung beschreibung",
+  description: "Beispiel0-SDN-Einfuehrung beschreibung",
   assignmentLabSheet: "../assignments/prona-sdn-intro-german.md",
 });
 

--- a/backend/src/Configuration.ts
+++ b/backend/src/Configuration.ts
@@ -316,6 +316,10 @@ environments.set("Beispiel0-SDN-Einfuehrung", {
   ],
   description: "Beispiel0-SDN-Einfuehrung beschreibung",
   assignmentLabSheet: "../assignments/prona-sdn-intro-german.md",
+  rootPath: "/home/p4/",
+  workspaceFolders: ["/home/p4/p4-boilerplate/Example0-SDN-Intro/"],
+  useCollaboration: true,
+  useLanguageClient: true,
 });
 
 environments.set("Example1-Repeater", {


### PR DESCRIPTION
removed umlaut from SDN lab example to prevent docker from crashing due to invalid character in container name, added collaboration and languageServer support for German SDN lab example