### PR TITLE
Fix Dockerfile to use locked dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,15 @@
+# Node modules
 node_modules
+frontend/node_modules
+backend/node_modules
+
+# Build folders
+frontend/build
+backend/dist
+backend/static
+
+# Workers
+frontend/public/dist
+
 npm-debug.log
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,15 @@ EXPOSE 3001/tcp
 RUN useradd -m -s /bin/bash p4
 WORKDIR /home/p4/learn-sdn-hub
 
-# copy frontend and backend files to the image
+# copy necessary files to image
 COPY frontend frontend
 COPY backend backend
+COPY package.json .
+COPY package-lock.json .
 
-# build backend and frontend, create static backend
-RUN cd backend && npm install && npm run compile
-RUN cd frontend && npm install && npm run build && npm run create-static-backend
+# build frontend and create static backend
+RUN npm clean-install
+RUN cd frontend && npm run build && npm run create-static-backend
 
 # copy example startup script and use it as the entrypoint when running the container
 COPY examples/start-learn-sdn-hub.sh start-learn-sdn-hub.sh


### PR DESCRIPTION
This fixes #171 

The Dockerfile now copies package.json and package-lock.json too. Instead of installing the dependencies in each sub-project (e.g. frontend and backend) it now uses the workspaces defined in the main package.json to handle this (only one install call). For reproducible builds "clean-install" is now used as this operation **never** modifies the lock file (in contrast to the regular install command).

The .dockerignore now includes all unnecessary folders that should not be copied to the image.