### PR TITLE
fixed maxlistener prob on console websocket listeners also testing copilot issue handling assistance capabilites

### DIFF
--- a/backend/src/consoles/SSHConsole.ts
+++ b/backend/src/consoles/SSHConsole.ts
@@ -120,6 +120,7 @@ export default class SSHConsole extends EventEmitter implements Console {
         }
       });
       sshConsole.on("close", () => {
+        console.log("SSHConsole: CLOSE on.close line 122");
         //console.debug("SSH connection closed.");
         sshConsole.ready = false;
         this.stream?.end();
@@ -175,6 +176,7 @@ export default class SSHConsole extends EventEmitter implements Console {
                       // );
                     })
                     .on("close", () => {
+                      console.log("SSHConsole: CLOSE on.close line 178");
                       // console.debug(
                       //   "SSH Client connection via jump host :: close",
                       // );
@@ -207,6 +209,7 @@ export default class SSHConsole extends EventEmitter implements Console {
           })
           .on("close", () => {
             //console.debug("SSH jumphost connection close");
+            console.log("SSHConsole: CLOSE on.close line 211");
             this.stream?.end();
             sshConsole.end();
             sshJumpHostConnection.end();
@@ -239,6 +242,13 @@ export default class SSHConsole extends EventEmitter implements Console {
           .on("ready", function () {
             //console.debug("SSH Client :: ready");
           })
+          .on("close", () => {
+            console.log("SSHConsole: CLOSE on.close line 245");
+            //console.debug("SSH Client :: close");
+            this.stream?.end();
+            sshConsole.end();
+            this.emit("close");
+          })
           .on("error", (err) => {
             console.error("SSH console error: ", err);
           })
@@ -266,6 +276,7 @@ export default class SSHConsole extends EventEmitter implements Console {
         this.stream = stream;
         stream
           .on("close", () => {
+            console.log("SSHConsole: CLOSE on.close line 278");
             //console.debug("SSH Stream :: close")
             stream.end();
             this.emit("close");
@@ -294,6 +305,7 @@ export default class SSHConsole extends EventEmitter implements Console {
           if (err) throw err;
           stream
             .on("close", function (code: string, signal: string) {
+              console.log("SSHConsole: CLOSE on.close line 307");
               //console.debug(
               //  "Stream :: close :: code: " + code + ", signal: " + signal,
               //);
@@ -326,6 +338,7 @@ export default class SSHConsole extends EventEmitter implements Console {
   }
 
   close(environmentId: string, groupNumber: number): void {
+    console.log("SSHConsole: CLOSE on.close line 340");
     //console.debug("SSH console close");
     SSHConsole.sshConnections.forEach((value, key, map) => {
       // if the connection is in the same group and environment, close it

--- a/backend/src/consoles/SSHConsole.ts
+++ b/backend/src/consoles/SSHConsole.ts
@@ -8,6 +8,11 @@ export interface Console {
     listener: () => void,
   ): this;
   on(event: "data", listener: (data: string) => void): this;
+  off(
+    event: "ready" | "close" | "closed" | "finished",
+    listener: () => void,
+  ): this;
+  off(event: "data", listener: (data: string) => void): this;
   write(data: string): void;
   writeLine(data: string): void;
   close(environmentId: string, groupNumber: number, sessionId?: string): void;

--- a/backend/src/providers/ProxmoxProvider.ts
+++ b/backend/src/providers/ProxmoxProvider.ts
@@ -1583,7 +1583,15 @@ export default class ProxmoxProvider implements InstanceProvider {
       if (connected) return;
 
       usedTime = Math.floor((Date.now() - startTime) / 1000);
-      await this.sleep(1000);
+      // use randomized sleep to avoid thundering herd problem due to single ssh jump host
+      // other option is to increase MaxStartups 10:30:60 (default only 10 unauth incoming conns) 
+      // and MaxSessions (default: 10) maybe also /proc/sys/net/core/somaxconn on ssh jump host
+      // otherwise in log on jumphost: "learn-sdn-hub-r1 ssh.socket Too many imcoming connections",
+      const sleepTime = 500 + Math.floor(Math.random() * 2500);
+      console.log(
+        `ProxmoxProvider: Waiting for SSH connection to ${ip}:${port}... (${usedTime}s elapsed, retrying in ${sleepTime}ms)`,
+      );
+      await this.sleep(sleepTime);
     }
 
     throw new Error("ProxmoxProvider: Timed out waiting for SSH connection.");

--- a/backend/src/websocket/LanguageServerHandler.ts
+++ b/backend/src/websocket/LanguageServerHandler.ts
@@ -110,11 +110,13 @@ export default function (
               console.log("SSH jumphost lsp connection close");
               sshJumpHostConnection.end();
               sshForwardServer.close();
+              wsFromBrowser.close();
             })
             .on("error", (err) => {
               console.log("SSH jumphost lsp connection error: " + err.message);
               sshJumpHostConnection.end();
               sshForwardServer.close();
+              wsFromBrowser.close();
             })
             .connect({
               host: jumpHost.ipaddress,


### PR DESCRIPTION
fixed leak of listeners on websockets when consoles are changed, that led to #247. In issue #247 also the number of ssh conns to jumphost was exceeded, e.g., when a large number of students deployed assignments, added randomized wait for conn retry over jumphost and added hints in code to increase sshd incoming conn limit if further improvement is needed, however this is currently not necessary in our setup and randomization should allow for using the default of 10 sessions max and 10 max incoming unhandled conns 